### PR TITLE
Fix extrusion depth parameter binding

### DIFF
--- a/Revit.FamilyEditor/ImportFamily.cs
+++ b/Revit.FamilyEditor/ImportFamily.cs
@@ -162,7 +162,10 @@ namespace Revit.FamilyEditor
                 Parameter extDepthParam = extrusion.get_Parameter(BuiltInParameter.EXTRUSION_END_PARAM);
                 if (extDepthParam != null)
                 {
-                    fm.SetFormula(param, param.Definition.Name);
+                    if (!fm.IsAssociated(extDepthParam))
+                    {
+                        fm.AssociateElementParameter(extDepthParam, param);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- update `BindExtrusionDepth` to associate extrusion depth with the family parameter instead of using `SetFormula`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684d75e458488332a6e1950a4a0cf5a4